### PR TITLE
handle keyboard events for viewport div only, not entire window

### DIFF
--- a/event_tracker.js
+++ b/event_tracker.js
@@ -184,9 +184,9 @@ class EventTracker {
   }
 
   start() {
-    window.addEventListener( 'keypress',   this.keyPress,  false );
-    window.addEventListener( 'keyup',      this.keyUp,     false );
-    window.addEventListener( 'keydown',    this.keyDown,   false );
+    this.dom_element.addEventListener( 'keypress',   this.keyPress,  false );
+    this.dom_element.addEventListener( 'keyup',      this.keyUp,     false );
+    this.dom_element.addEventListener( 'keydown',    this.keyDown,   false );
     this.dom_element.addEventListener( 'mousedown',  this.mouseDown,  false );
     this.dom_element.addEventListener( 'mousewheel', this.mouseWheel, false );
     this.dom_element.addEventListener( 'mousemove', this.mouseMove, false);

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
         <div id="year-slider-placeholder"></div>
       </div>
     </header>
-    <div id="viewport">
+    <div id="viewport" tabindex="-1">
       <img id="street-level-img" class="eyelevel-button eyelevel-img-hidden" src="images/street_level.png">
       <img id="bird-level-img" class="eyelevel-button eyelevel-img-hidden" src="images/bird_level.png">
       <img id="info-img" class="info-button" src="images/info.png">


### PR DESCRIPTION
fixes bug which causes arrow keys to pan the camera in addition to moving the time slider if keyboard focus is on the slider
