### PR TITLE
add antialiasing using FXAA shader

### DIFF
--- a/app.js
+++ b/app.js
@@ -696,11 +696,19 @@ class App {
     this.composer = new THREE.EffectComposer(this.renderer);
     this.renderPass = new THREE.RenderPass(this.scene, this.camera);
     this.composer.addPass(this.renderPass);
+
     this.outlinePass = new THREE.OutlinePass(new THREE.Vector2(this.container.offsetWidth, this.container.offsetHeight), this.scene, this.camera);
     this.outlinePass.edgeStrength = 5.0;
     this.outlinePass.edgeGlow = 0.5;
     this.outlinePass.edgeThickness = 2.0;
     this.composer.addPass(this.outlinePass);
+
+    // Set up antialiasing.
+    this.fxaaPass = new THREE.ShaderPass(THREE.FXAAShader);
+    const pixelRatio = this.renderer.getPixelRatio();
+    this.fxaaPass.material.uniforms['resolution'].value.x = 1 / (this.container.offsetWidth * pixelRatio);
+    this.fxaaPass.material.uniforms['resolution'].value.y = 1 / (this.container.offsetHeight * pixelRatio);
+    this.composer.addPass(this.fxaaPass); 
 
     if (this.debug) {
       this.axes = Axes.axes3D({

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <script src="https://www.gstatic.com/external_hosted/threejs-r108/examples/js/postprocessing/OutlinePass.js"></script>
     <script src="https://www.gstatic.com/external_hosted/threejs-r108/examples/js/postprocessing/ShaderPass.js"></script>
     <script src="https://www.gstatic.com/external_hosted/threejs-r108/examples/js/shaders/CopyShader.js"></script>
+    <script src="https://www.gstatic.com/external_hosted/threejs-r108/examples/js/shaders/FXAAShader.js"></script>
     <script src="./third_party/vector_tile_js/vector-tile.js"></script>
     <script type="module" src="main.js"></script>
     <!--# include file="/assets/analytics.html" -->


### PR DESCRIPTION
![change_difference](https://user-images.githubusercontent.com/9429048/104165390-336df500-53f1-11eb-9b8c-2db079f887b0.png)

Removes the aliasing of buildings and footpaths using screen-space antialiasing. Also smooths out the outlines of buildings in "info" mode.